### PR TITLE
Bug: Fix linking with stdc++ 

### DIFF
--- a/packages/cli/src/cmds/cmd_build/link.rs
+++ b/packages/cli/src/cmds/cmd_build/link.rs
@@ -18,7 +18,7 @@ pub async fn build_elf(
     link_cmd_path: &Path,
 ) -> cu::Result<bool> {
     let env = environment();
-    let mut args = ldflags;
+    let mut args = vec![];
 
     // sort so args are always comparable regardless of compilation order
     objects.sort();
@@ -28,7 +28,7 @@ pub async fn build_elf(
     for lib in static_libs {
         args.push(lib.into_utf8()?);
     }
-
+    args.extend(ldflags);
     args.push(format!("-o{}", out_path.to_owned().into_utf8()?));
 
     let linker = env.cc();


### PR DESCRIPTION
Moves library flags (`-l`) after objects in linker command.
Manual test plan: Add `stdc++` to the Megaton.toml config field `build.libraries`, build a mod with it and see that the check step passes successfully.