### PR TITLE
Feat/package cxx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +632,7 @@ dependencies = [
 name = "megaton-cmd"
 version = "0.1.0"
 dependencies = [
+ "cargo_metadata",
  "depfile",
  "derive_more",
  "flate2",
@@ -861,6 +895,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -994,6 +1032,26 @@ checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -22,6 +22,7 @@ walkdir = "2.5.0"
 fxhash = "0.2.1"
 depfile = "0.1.1"
 regex = "1.12.2"
+cargo_metadata = "0.23.1"
 
 [build-dependencies.cu]
 workspace = true

--- a/packages/cli/src/cmds/cmd_build/mod.rs
+++ b/packages/cli/src/cmds/cmd_build/mod.rs
@@ -81,6 +81,7 @@ async fn run_build(args: CmdBuild) -> cu::Result<()> {
     if lib_enabled && let Some(rust_ctx) = rust_ctx {
         let rust_ctx =
             rust_ctx.context("Rust is enabled, but cargo context could not be initialized")?;
+        rust_ctx.check_cxx_version()?;
 
         if !args.configure {
             need_link |= rust_ctx

--- a/packages/cli/src/cmds/cmd_build/rust.rs
+++ b/packages/cli/src/cmds/cmd_build/rust.rs
@@ -19,6 +19,8 @@ pub struct RustCtx {
     header_suffix: String,
 }
 
+static BLESSED_CXX_VERSION: &'static str = "1.0.194";
+
 impl RustCtx {
     /// Gets the crate based on the cargo config. Returns `None` if rust is
     /// disabled or can't be automatically enabled. Returns Some(Err()) if
@@ -261,6 +263,7 @@ async fn cxxbridge_process(
 // Run the cxxbridge cmd and update the corresponding file if changed
 // returns Ok(true) iff new code was generated and written
 async fn cxxbridge_cmd(file: Option<&Path>, header: bool, output: &Path) -> cu::Result<bool> {
+    let env = environment();
     let mut args = vec![];
     if let Some(file) = file {
         args.push(cu::check!(file.to_str(), "Not utf-8: {}", file.display())?);
@@ -269,8 +272,14 @@ async fn cxxbridge_cmd(file: Option<&Path>, header: bool, output: &Path) -> cu::
         args.push("--header");
     }
 
-    let exe = cu::which("cxxbridge")
-        .context("cxxbridge executable not found; `cargo install cxxbridge-cmd`")?;
+    let exe = env.cxxbridge();
+    if !exe.exists() {
+        cu::debug!("cxxbridge-cmd not installed, installing to MEGATON_HOME/bin");
+        install_cxxbridge(env.home())
+            .await
+            .context("Failed to install cxxbridge Make sure you are connected to the internet")?;
+    }
+
     let command = exe
         .command()
         .stdout(cu::pio::buffer())
@@ -296,6 +305,24 @@ async fn cxxbridge_cmd(file: Option<&Path>, header: bool, output: &Path) -> cu::
         }
         None => cu::bail!("cxxbridge terminated early"),
     }
+}
+
+async fn install_cxxbridge(dir: &Path) -> cu::Result<()> {
+    cu::fs::make_dir(dir)?;
+    let dir = dir.as_utf8()?;
+    let command = cu::which("cargo")?
+        .command()
+        .add(cu::args![
+            "install",
+            "--root",
+            dir,
+            "--no-track",
+            "-q", // suppress warning about adding ./bin to path
+            format!("cxxbridge-cmd@{BLESSED_CXX_VERSION}"),
+        ])
+        .preset(cu::pio::cargo("Installing cxxbridge-cmd"));
+
+    command.co_spawn().await?.0.co_wait_nz().await
 }
 
 fn write_if_changed(path: &Path, bytes: &[u8]) -> cu::Result<bool> {

--- a/packages/cli/src/cmds/cmd_build/rust.rs
+++ b/packages/cli/src/cmds/cmd_build/rust.rs
@@ -80,9 +80,12 @@ impl RustCtx {
             .manifest_path(&self.manifest)
             .exec()?;
 
-        let cxx = match metadata.packages.iter().find(|pack| pack.name == "cxx"){
+        let cxx = match metadata.packages.iter().find(|pack| pack.name == "cxx") {
             Some(package) => package,
-            None => return Ok(()),
+            None => {
+                cu::debug!("cxx package not found, skipping cxx version check");
+                return Ok(());
+            }
         };
 
         let blessed_version = Version::parse(BLESSED_CXX_VERSION).unwrap();

--- a/packages/cli/src/cmds/cmd_build/rust.rs
+++ b/packages/cli/src/cmds/cmd_build/rust.rs
@@ -78,31 +78,27 @@ impl RustCtx {
         let metadata = MetadataCommand::new()
             .manifest_path(&self.manifest)
             .exec()?;
-
-        let root_deps = &metadata.root_package().unwrap().dependencies;
-        let cxx_req= &cu::check!(
-            root_deps.iter().find(|dep| dep.name == "cxx"),
-            "Failed to find cxx in package dependencies: make sure to add `cxx = \"{}\"` to the root cargo package",
+        let cxx = cu::check!(
+            metadata.packages.iter().find(|pack| pack.name == "cxx"),
+            "failed to find cxx package\ntry adding this line to your cargo dependencies: `cxx = \"={}\"`",
             BLESSED_CXX_VERSION
-        )?.req;
-
-        let blessed_version = Version::parse(BLESSED_CXX_VERSION)?;
-
-        let mut older = blessed_version.clone();
-        older.patch -= 1;
-        if cxx_req.matches(&older) {
-            cu::error!("please use exact cxx version `={}`", BLESSED_CXX_VERSION);
-            cu::bail!("bad cxx version: allows version older than what megaton supports");
+        )?;
+        let blessed_version = Version::parse(BLESSED_CXX_VERSION).unwrap();
+        if cxx.version < blessed_version {
+            cu::bail!(
+                "cxx version is older than the supported version; supported: {}, found: {} ",
+                blessed_version,
+                cxx.version
+            );
+        }
+        if cxx.version > blessed_version {
+            cu::warn!(
+                "cxx version is newer than the supported version; supported: {}, found: {}",
+                blessed_version,
+                cxx.version
+            );
         }
 
-        let mut newer = blessed_version.clone();
-        newer.patch += 1;
-        if cxx_req.matches(&newer) {
-            cu::warn!("please use exact cxx version `={}`", BLESSED_CXX_VERSION);
-            cu::warn!("cxx version might be newer than megaton currently supports");
-        } else {
-            cu::debug!("cxx version check passed with no issues");
-        }
         Ok(())
     }
 

--- a/packages/cli/src/cmds/cmd_build/rust.rs
+++ b/packages/cli/src/cmds/cmd_build/rust.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
 };
 
+use cargo_metadata::{MetadataCommand, semver::Version};
 use cu::pre::*;
 
 use crate::env::environment;
@@ -19,7 +20,7 @@ pub struct RustCtx {
     header_suffix: String,
 }
 
-static BLESSED_CXX_VERSION: &'static str = "1.0.194";
+static BLESSED_CXX_VERSION: &str = "1.0.194";
 
 impl RustCtx {
     /// Gets the crate based on the cargo config. Returns `None` if rust is
@@ -55,6 +56,8 @@ impl RustCtx {
 
         let crate_root = manifest.parent().unwrap();
 
+        cu::debug!("checking cxx version");
+
         let source_paths = sources
             .iter()
             .map(|rel_path| crate_root.join(rel_path))
@@ -69,6 +72,38 @@ impl RustCtx {
             source_paths,
             header_suffix,
         })
+    }
+
+    pub fn check_cxx_version(&self) -> cu::Result<()> {
+        let metadata = MetadataCommand::new()
+            .manifest_path(&self.manifest)
+            .exec()?;
+
+        let root_deps = &metadata.root_package().unwrap().dependencies;
+        let cxx_req= &cu::check!(
+            root_deps.iter().find(|dep| dep.name == "cxx"),
+            "Failed to find cxx in package dependencies: make sure to add `cxx = \"{}\"` to the root cargo package",
+            BLESSED_CXX_VERSION
+        )?.req;
+
+        let blessed_version = Version::parse(BLESSED_CXX_VERSION)?;
+
+        let mut older = blessed_version.clone();
+        older.patch -= 1;
+        if cxx_req.matches(&older) {
+            cu::error!("please use exact cxx version `={}`", BLESSED_CXX_VERSION);
+            cu::bail!("bad cxx version: allows version older than what megaton supports");
+        }
+
+        let mut newer = blessed_version.clone();
+        newer.patch += 1;
+        if cxx_req.matches(&newer) {
+            cu::warn!("please use exact cxx version `={}`", BLESSED_CXX_VERSION);
+            cu::warn!("cxx version might be newer than megaton currently supports");
+        } else {
+            cu::debug!("cxx version check passed with no issues");
+        }
+        Ok(())
     }
 
     pub fn has_build_script(&self) -> bool {

--- a/packages/cli/src/cmds/cmd_build/rust.rs
+++ b/packages/cli/src/cmds/cmd_build/rust.rs
@@ -79,11 +79,12 @@ impl RustCtx {
         let metadata = MetadataCommand::new()
             .manifest_path(&self.manifest)
             .exec()?;
-        let cxx = cu::check!(
-            metadata.packages.iter().find(|pack| pack.name == "cxx"),
-            "failed to find cxx package\ntry adding this line to your cargo dependencies: `cxx = \"={}\"`",
-            BLESSED_CXX_VERSION
-        )?;
+
+        let cxx = match metadata.packages.iter().find(|pack| pack.name == "cxx"){
+            Some(package) => package,
+            None => return Ok(()),
+        };
+
         let blessed_version = Version::parse(BLESSED_CXX_VERSION).unwrap();
         if cxx.version < blessed_version {
             cu::bail!(

--- a/packages/cli/src/env/mod.rs
+++ b/packages/cli/src/env/mod.rs
@@ -27,6 +27,8 @@ pub struct Environment {
     devkitpro: PathBuf,
     dkp_version: String,
     dkp_includes: Vec<String>,
+
+    cxxbridge: PathBuf,
 }
 
 impl Environment {
@@ -51,6 +53,8 @@ impl Environment {
             .expect("Failed to init environment: check that DKP is installed correctly");
         let dkp_includes = get_dkp_includes(&devkitpro, &dkp_version);
 
+        let cxxbridge = megaton_home.join("bin").join("cxxbridge");
+
         Self {
             megaton_home,
             cc,
@@ -66,6 +70,7 @@ impl Environment {
             devkitpro,
             dkp_version,
             dkp_includes,
+            cxxbridge,
         }
     }
 
@@ -111,6 +116,9 @@ impl Environment {
     }
     pub fn asm_version(&self) -> &str {
         &self.asm_version
+    }
+    pub fn cxxbridge(&self) -> &Path {
+        &self.cxxbridge
     }
 }
 


### PR DESCRIPTION
Automatically installs cxxbridge-cmd to the megaton home if not already installed

Uses cargo-metadata to make sure that cxx is included in the root crate package and the semver doesn't allow for versions outside of the 'blessed' version