### PR TITLE
Changed version check to use semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "fxhash",
  "pistonite-cu",
  "regex",
+ "semver",
  "serde",
  "sha2",
  "tar",
@@ -858,9 +859,13 @@ checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
-    "packages/cli", 
+    "packages/cli",
     "packages/lib",
 ]
 

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -22,6 +22,7 @@ walkdir = "2.5.0"
 fxhash = "0.2.1"
 depfile = "0.1.1"
 regex = "1.12.2"
+semver = { version = "1.0.28", features = ["serde"] }
 
 [build-dependencies.cu]
 workspace = true

--- a/packages/cli/src/cmds/cmd_build/config/main_config.rs
+++ b/packages/cli/src/cmds/cmd_build/config/main_config.rs
@@ -5,9 +5,10 @@
 use std::path::{Path, PathBuf};
 
 use cu::pre::*;
+use semver::{Version, VersionReq};
 
 use super::{BASE_PROFILE, Build, CaptureUnused, ExtendProfile, Profile, Validate, ValidateCtx};
-use crate::MEGATON_VERSION;
+use crate::MEGATON_VERSION_STRING;
 
 /// Load a Megaton.toml config file
 pub fn load_config(manifest_path: impl AsRef<Path>) -> cu::Result<Config> {
@@ -147,9 +148,8 @@ impl Validate for CargoConfig {
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MegatonConfig {
     /// If specified, megaton will run version check
-    ///
-    /// `N` means the build tool must be version `0.N.x` (x can be anything)
-    pub version: Option<String>,
+    /// Will error if
+    pub version: Option<Version>,
 
     /// Custom entry point symbol for the module. This should only be set if libmegaton is disabled.
     /// Using this disables the libmegaton runtime, which also means rust support will be disabled.
@@ -162,33 +162,37 @@ pub struct MegatonConfig {
 impl Validate for MegatonConfig {
     fn validate(&self, ctx: &mut ValidateCtx) -> cu::Result<()> {
         if let Some(v) = &self.version {
-            check_version(v, MEGATON_VERSION)?
+            check_version(v)?
         }
         self.unused.validate(ctx)
     }
 }
 
-fn check_version(checked_version: &str, real_version: &str) -> cu::Result<()> {
-    let mut version = checked_version.splitn(3, '.');
-    let ver_major = cu::check!(version.next(), "invalid format: {}", checked_version)?;
-    let ver_minor = cu::check!(version.next(), "invalid format: {}", checked_version)?;
-    let ver_patch = cu::check!(version.next(), "invalid format: {}", checked_version)?;
-    let mut real = real_version.splitn(3, '.');
-    let real_major = real.next().unwrap();
-    let real_minor = real.next().unwrap();
-    let real_patch = real.next().unwrap();
-    if ver_major != real_major || ver_minor != real_minor {
-        cu::bail!(
-            "megaton.version: major and minor version must match {}.{}.X",
-            real_major,
-            real_minor
+fn check_version(version: &Version) -> cu::Result<()> {
+    let true_version = Version::parse(MEGATON_VERSION_STRING).expect(&format!(
+        "Failed to parse megaton version string: {MEGATON_VERSION_STRING}"
+    ));
+    let needed_version_req =
+        VersionReq::parse(&format!("={}.{}", true_version.major, true_version.minor)).unwrap();
+    let exact_version_req = VersionReq::parse(&format!(
+        "={}.{}.{}",
+        true_version.major, true_version.minor, true_version.patch
+    ))
+    .unwrap();
+
+    if !needed_version_req.matches(version) {
+        cu::error!(
+            "Version check: major/minor version do not match\n\tConfig: {} | Megaton version: {}",
+            version,
+            true_version
         );
+        cu::bail!("Version check failed");
     }
-    if ver_patch != real_patch {
-        cu::hint!(
-            "Megaton patch number has changed - config: {}, megaton: {}",
-            checked_version,
-            real_version
+    if !exact_version_req.matches(version) {
+        cu::warn!(
+            "Version check: patch number does not match\n\tConfig: {} | Megaton version: {}",
+            version,
+            true_version
         );
     }
     Ok(())

--- a/packages/cli/src/cmds/cmd_build/config/main_config.rs
+++ b/packages/cli/src/cmds/cmd_build/config/main_config.rs
@@ -8,7 +8,6 @@ use cu::pre::*;
 use semver::{Version, VersionReq};
 
 use super::{BASE_PROFILE, Build, CaptureUnused, ExtendProfile, Profile, Validate, ValidateCtx};
-use crate::MEGATON_VERSION_STRING;
 
 /// Load a Megaton.toml config file
 pub fn load_config(manifest_path: impl AsRef<Path>) -> cu::Result<Config> {
@@ -147,9 +146,10 @@ impl Validate for CargoConfig {
 /// The `[megaton]` section
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MegatonConfig {
-    /// If specified, megaton will run version check
-    /// Will error if
-    pub version: Option<Version>,
+    /// If specified, megaton will run version check and error if the current
+    /// version doesn't match the given requirement. To only check minor version,
+    /// pass a version of the form `0.{minor}.*`
+    pub version: Option<VersionReq>,
 
     /// Custom entry point symbol for the module. This should only be set if libmegaton is disabled.
     /// Using this disables the libmegaton runtime, which also means rust support will be disabled.
@@ -168,32 +168,15 @@ impl Validate for MegatonConfig {
     }
 }
 
-fn check_version(version: &Version) -> cu::Result<()> {
-    let true_version = Version::parse(MEGATON_VERSION_STRING).unwrap_or_else(|_| {
-        panic!("Failed to parse megaton version string: {MEGATON_VERSION_STRING}")
-    });
-    let needed_version_req =
-        VersionReq::parse(&format!("={}.{}", true_version.major, true_version.minor)).unwrap();
-    let exact_version_req = VersionReq::parse(&format!(
-        "={}.{}.{}",
-        true_version.major, true_version.minor, true_version.patch
-    ))
-    .unwrap();
-
-    if !needed_version_req.matches(version) {
+fn check_version(version_req: &VersionReq) -> cu::Result<()> {
+    let true_version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    if !version_req.matches(&true_version) {
         cu::error!(
-            "Version check: major/minor version do not match\n\tConfig: {} | Megaton version: {}",
-            version,
-            true_version
+            "Version check: version {} does not match requirement {}",
+            true_version,
+            version_req
         );
         cu::bail!("Version check failed");
-    }
-    if !exact_version_req.matches(version) {
-        cu::warn!(
-            "Version check: patch number does not match\n\tConfig: {} | Megaton version: {}",
-            version,
-            true_version
-        );
     }
     Ok(())
 }

--- a/packages/cli/src/cmds/cmd_build/config/main_config.rs
+++ b/packages/cli/src/cmds/cmd_build/config/main_config.rs
@@ -169,9 +169,9 @@ impl Validate for MegatonConfig {
 }
 
 fn check_version(version: &Version) -> cu::Result<()> {
-    let true_version = Version::parse(MEGATON_VERSION_STRING).expect(&format!(
-        "Failed to parse megaton version string: {MEGATON_VERSION_STRING}"
-    ));
+    let true_version = Version::parse(MEGATON_VERSION_STRING).unwrap_or_else(|_| {
+        panic!("Failed to parse megaton version string: {MEGATON_VERSION_STRING}")
+    });
     let needed_version_req =
         VersionReq::parse(&format!("={}.{}", true_version.major, true_version.minor)).unwrap();
     let exact_version_req = VersionReq::parse(&format!(

--- a/packages/cli/src/cmds/cmd_build/mod.rs
+++ b/packages/cli/src/cmds/cmd_build/mod.rs
@@ -16,7 +16,7 @@ mod config;
 mod link;
 mod rust;
 
-/// Manage the custom `megaton` Rust toolchain
+/// Compile and link the megaton project
 #[derive(Debug, Clone, AsRef, clap::Parser)]
 pub struct CmdBuild {
     /// Select profile to build

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -4,4 +4,4 @@
 pub mod cmds;
 pub mod env;
 
-pub static MEGATON_VERSION: &str = "0.1.1";
+pub static MEGATON_VERSION_STRING: &str = "0.1.0";

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -3,5 +3,3 @@
 
 pub mod cmds;
 pub mod env;
-
-pub static MEGATON_VERSION_STRING: &str = "0.1.0";


### PR DESCRIPTION
Functionality is basically the same, but the config parser should more reliably parse the version string as a semver::Version.

Warns if patch number is differnt. Fails if major/minor version are different.