### PR TITLE
If cargo enabled, add megaton rust lib as local crate dependency

### DIFF
--- a/packages/cli/src/cmds/cmd_build/mod.rs
+++ b/packages/cli/src/cmds/cmd_build/mod.rs
@@ -62,6 +62,7 @@ async fn run_build(args: CmdBuild) -> cu::Result<()> {
     let target_mod_include = target_mod.join("include");
     let target_mod_o = target_mod.join("o");
     let compile_db_path = target_mod.join("compiledb.cache");
+    let target_lib = profile_target.join("lib");
     cu::fs::make_dir(&target_mod_src)?;
     cu::fs::make_dir(&target_mod_include)?;
     cu::fs::make_dir(&target_mod_o)?;
@@ -75,12 +76,19 @@ async fn run_build(args: CmdBuild) -> cu::Result<()> {
     let mut static_libs = vec![];
     let mut need_link = false;
 
+    if lib_enabled {
+        cu::debug!("Cmd_build: libmegaton enabled");
+        install_lib_if_needed(&target_lib)?;
+    }
+
     ////////// Build rust //////////
     let rust_ctx = rust::RustCtx::from_config(config.cargo);
     let rust_enabled = rust_ctx.is_some();
     if lib_enabled && let Some(rust_ctx) = rust_ctx {
         let rust_ctx =
             rust_ctx.context("Rust is enabled, but cargo context could not be initialized")?;
+
+        rust_ctx.add_megaton_rust_lib(&target_lib).await.context("Failed to add megaton rust library, ensure libmegaton was properly installed")?;
 
         if !args.configure {
             need_link |= rust_ctx
@@ -111,14 +119,6 @@ async fn run_build(args: CmdBuild) -> cu::Result<()> {
 
     // If libmegaton enabled, create library context
     if lib_enabled {
-        cu::debug!("Cmd_build: libmegaton enabled");
-        let target_lib = profile_target.join("lib");
-
-        if lib_needs_unpacked(&target_lib) {
-            cu::hint!("Installing libmegaton");
-            unpack_lib(&target_lib).context("Failed to unpack library archive")?;
-        }
-
         // Add public library includes
         build_flags.add_includes([target_lib.join("include").into_utf8()?]);
 
@@ -248,6 +248,14 @@ async fn run_build(args: CmdBuild) -> cu::Result<()> {
 
 static LIBRARY_TARGZ: &[u8] = include_bytes!("../../../libmegaton.tar.gz");
 static LIBRARY_HASH: &[u8] = include_bytes!("../../../libmegaton_sha256sum");
+
+fn install_lib_if_needed(lib_path: &Path) -> cu::Result<()> {
+    if lib_needs_unpacked(lib_path) {
+        cu::hint!("Installing libmegaton");
+        unpack_lib(lib_path).context("Failed to unpack library archive")?;
+    }
+    Ok(())
+}
 
 /// True if version hash doesn't exist or doesn't match the stored tarball
 fn lib_needs_unpacked(lib_path: &Path) -> bool {

--- a/packages/cli/src/cmds/cmd_build/mod.rs
+++ b/packages/cli/src/cmds/cmd_build/mod.rs
@@ -88,7 +88,9 @@ async fn run_build(args: CmdBuild) -> cu::Result<()> {
         let rust_ctx =
             rust_ctx.context("Rust is enabled, but cargo context could not be initialized")?;
 
-        rust_ctx.add_megaton_rust_lib(&target_lib).await.context("Failed to add megaton rust library, ensure libmegaton was properly installed")?;
+        rust_ctx.add_megaton_rust_lib(&target_lib).await.context(
+            "Failed to add megaton rust library, ensure libmegaton was properly installed",
+        )?;
 
         if !args.configure {
             need_link |= rust_ctx

--- a/packages/cli/src/cmds/cmd_build/rust.rs
+++ b/packages/cli/src/cmds/cmd_build/rust.rs
@@ -12,6 +12,7 @@ use crate::env::environment;
 
 use super::config::CargoConfig;
 
+#[derive(Debug, Clone)]
 pub struct RustCtx {
     pub manifest: PathBuf,
     target_path: PathBuf,
@@ -72,6 +73,26 @@ impl RustCtx {
     pub fn has_build_script(&self) -> bool {
         let script = self.manifest.parent().unwrap().join("build.rs");
         script.exists()
+    }
+
+    /// Add the megaton rust library to the crate
+    /// libmegaton must be installed when this is called
+    pub async fn add_megaton_rust_lib(&self, lib_path: &Path) -> cu::Result<()> {
+        let cargo = cu::which("cargo")
+            .context("Cargo executable not found: ensure rust is properly installed")?;
+        let command = cargo
+            .command()
+            .add(cu::args![
+                "add",
+                "--manifest-path",
+                &self.manifest,
+                "--path",
+                lib_path,
+            ])
+            .stdio_null()
+            .stderr(cu::lv::I);
+
+        command.co_wait_nz().await
     }
 
     /// Build the rust crate with `cargo build +megaton`


### PR DESCRIPTION
adding so that we can build rust code in the library

This calls cargo add on every run to ensure it is installed.
It is slower, but not slower than checking with cargo metadata
beforehand.

I also moved the library install call earlier in the build process
